### PR TITLE
Update Heatpump IAM

### DIFF
--- a/examples/heat_pump/src/heat_pump.c
+++ b/examples/heat_pump/src/heat_pump.c
@@ -273,13 +273,6 @@ bool load_iam_policy(struct heat_pump* heatPump)
         nm_iam_configuration_role_add_policy(r, "ManageOwnUser");
         nm_iam_configuration_add_role(conf, r);
     }
-    {
-        //TODO: guest should have access to LocalHeatpumpControl and LocalDeviceInfo
-        struct nm_iam_role* r = nm_iam_configuration_role_new("Guest");
-        nm_iam_configuration_role_add_policy(r, "ManageOwnUser");
-        nm_iam_configuration_role_add_policy(r, "Pairing");
-        nm_iam_configuration_add_role(conf, r);
-    }
 
     // Connections which does not have a paired user in the system gets the Unpaired role.
     nm_iam_configuration_set_unpaired_role(conf, "Unpaired");

--- a/examples/heat_pump/src/heat_pump.c
+++ b/examples/heat_pump/src/heat_pump.c
@@ -273,6 +273,13 @@ bool load_iam_policy(struct heat_pump* heatPump)
         nm_iam_configuration_role_add_policy(r, "ManageOwnUser");
         nm_iam_configuration_add_role(conf, r);
     }
+    {
+        //TODO: guest should have access to LocalHeatpumpControl and LocalDeviceInfo
+        struct nm_iam_role* r = nm_iam_configuration_role_new("Guest");
+        nm_iam_configuration_role_add_policy(r, "ManageOwnUser");
+        nm_iam_configuration_role_add_policy(r, "Pairing");
+        nm_iam_configuration_add_role(conf, r);
+    }
 
     // Connections which does not have a paired user in the system gets the Unpaired role.
     nm_iam_configuration_set_unpaired_role(conf, "Unpaired");

--- a/examples/heat_pump/src/heat_pump_state.c
+++ b/examples/heat_pump/src/heat_pump_state.c
@@ -125,9 +125,9 @@ void create_default_iam_state(NabtoDevice* device, const char* filename, struct 
     nm_iam_state_user_set_role(user, "Administrator");
     nm_iam_state_add_user(state, user);
     nm_iam_state_set_initial_pairing_username(state, "admin");
-    nm_iam_state_set_local_initial_pairing(state, true);
+    nm_iam_state_set_open_pairing_role(state, "Administrator");
+    nm_iam_state_set_local_initial_pairing(state, false);
     nm_iam_state_set_local_open_pairing(state, true);
-    nm_iam_state_set_open_pairing_role(state, "Standard");
     nm_iam_state_set_password_open_password(state, random_password(12));
     nm_iam_state_set_password_open_pairing(state, true);
     save_iam_state(filename, state, logger);

--- a/examples/heat_pump/src/heat_pump_state.c
+++ b/examples/heat_pump/src/heat_pump_state.c
@@ -1,6 +1,7 @@
 
 #include <apps/common/string_file.h>
 #include <apps/common/json_config.h>
+#include <apps/common/random_string.h>
 
 
 #include "heat_pump_state.h"
@@ -126,7 +127,9 @@ void create_default_iam_state(NabtoDevice* device, const char* filename, struct 
     nm_iam_state_set_initial_pairing_username(state, "admin");
     nm_iam_state_set_local_initial_pairing(state, true);
     nm_iam_state_set_local_open_pairing(state, true);
-    nm_iam_state_set_open_pairing_role(state, "Guest");
+    nm_iam_state_set_open_pairing_role(state, "Standard");
+    nm_iam_state_set_password_open_password(state, random_password(12));
+    nm_iam_state_set_password_open_pairing(state, true);
     save_iam_state(filename, state, logger);
     nm_iam_state_free(state);
 }


### PR DESCRIPTION
Updates heatpump example to new IAM scheme as per ticket 1315
* Disable local initial pairing
* Enable local open and password open pairing
* Put a random 12 characters long string as password for open password pairing