### PR TITLE
SC-1598

### DIFF
--- a/apps/tcp_tunnel_device/src/help.c
+++ b/apps/tcp_tunnel_device/src/help.c
@@ -15,11 +15,15 @@ void print_help() {
     printf("%s" NEWLINE, "                      is error, warn, info and trace.");
     printf("%s" NEWLINE, "      --random-ports  Bind the local and the p2p sockets to random UDP ports");
     printf("%s" NEWLINE, "                      instead of the default UDP ports 5592 and 5593.");
-    printf("%s" NEWLINE, "      --local-port    Bind the local socket to a specific UDP port");
-    printf("%s" NEWLINE, "                      instead of the default UDP port 5592.");
-    printf("%s" NEWLINE, "      --p2p-port      Bind the p2p socket to a specific UDP port");
-    printf("%s" NEWLINE, "                      instead of the default UDP port 5593.");
+    printf("%s" NEWLINE, "      --local-port    Bind the local socket to a specific UDP port instead of");
+    printf("%s" NEWLINE, "                      the default UDP port 5592.");
+    printf("%s" NEWLINE, "      --p2p-port      Bind the p2p socket to a specific UDP port instead of the");
+    printf("%s" NEWLINE, "                      default UDP port 5593");
     printf("%s" NEWLINE, "      --init          Interactively create configuration files the the tcp tunnel.");
+    printf("%s" NEWLINE, "      --demo-init     Interactively initialize the TCP tunnel for demo purposes.");
+    printf("%s" NEWLINE, "                      This option should be used if a quick proof of concept needs");
+    printf("%s" NEWLINE, "                      to be made for demo purposes. This should not be used in a");
+    printf("%s" NEWLINE, "                      production setup.");
     printf("%s" NEWLINE, "");
     printf("%s" NEWLINE, "# Files");
     printf("%s" NEWLINE, "");
@@ -27,7 +31,7 @@ void print_help() {
     printf("%s" NEWLINE, "the homedir: config, state and keys.");
     printf("%s" NEWLINE, "");
     printf("%s" NEWLINE, "The files are by default located in this folder on unix:");
-    printf("%s" NEWLINE, "`$HOME/.nabto/edge` and this on windows `%APPDATA%\\nabto\\edge`. The location can");
+    printf("%s" NEWLINE, "`$HOME/.nabto/edge` and this on Windows `%APPDATA%\\nabto\\edge`. The location can");
     printf("%s" NEWLINE, "be overriden by the home-dir option. In this case basefolder is");
     printf("%s" NEWLINE, "`${home-dir}`.");
     printf("%s" NEWLINE, "");
@@ -47,7 +51,7 @@ void print_help() {
     printf("%s" NEWLINE, "```");
     printf("%s" NEWLINE, "");
     printf("%s" NEWLINE, "The `ProductId` in the configuration is the product which is");
-    printf("%s" NEWLINE, "configured for the group of devices. The product id found in the cloud");
+    printf("%s" NEWLINE, "configured for the group of devices. The product id is found in the cloud");
     printf("%s" NEWLINE, "console.");
     printf("%s" NEWLINE, "");
     printf("%s" NEWLINE, "The `DeviceId` is the device id for this specific device. This device");
@@ -61,6 +65,7 @@ void print_help() {
     printf("%s" NEWLINE, "The `tcp_tunnel_iam.json` is an IAM policies file which contains the");
     printf("%s" NEWLINE, "policies and roles used by the system.");
     printf("%s" NEWLINE, "");
+    printf("%s" NEWLINE, "Read more about the IAM module on http://docs.nabto.com/developer/guides/iam/intro.html.");
     printf("%s" NEWLINE, "");
     printf("%s" NEWLINE, "## `state/tcp_tunnel_device_iam_state.json`");
     printf("%s" NEWLINE, "");

--- a/apps/tcp_tunnel_device/src/help.txt
+++ b/apps/tcp_tunnel_device/src/help.txt
@@ -6,20 +6,29 @@ TCP Tunnel Device Help.
   -H, --home-dir      Set alternative home dir, The default home dir is
                       $HOME/.nabto/edge on linux and mac, and %APPDATA%\nabto\edge
                       on windows
-      --log-level     Set the log level for the application; the possible levels
-                      are error, warn, info and trace.
+      --log-level     Set the log level for the application the possible levels
+                      is error, warn, info and trace.
       --random-ports  Bind the local and the p2p sockets to random UDP ports
                       instead of the default UDP ports 5592 and 5593.
+      --local-port    Bind the local socket to a specific UDP port instead of
+                      the default UDP port 5592.
+      --p2p-port      Bind the p2p socket to a specific UDP port instead of the
+                      default UDP port 5593
       --init          Interactively create configuration files the the tcp tunnel.
+      --demo-init     Interactively initialize the TCP tunnel for demo purposes.
+                      This option should be used if a quick proof of concept needs
+                      to be made for demo purposes. This should not be used in a
+                      production setup.
 
 # Files
 
 The application uses several files. They are located in subfolders of
 the homedir: config, state and keys.
 
-The files are by default located in the folder `$HOME/.nabto/edge` on Linux/macOS and
-`%APPDATA%\nabto\edge` on Windows. The location can be overriden by the home-dir option. In this
-case basefolder is `${home-dir}`.
+The files are by default located in this folder on unix:
+`$HOME/.nabto/edge` and this on Windows `%APPDATA%\nabto\edge`. The location can
+be overriden by the home-dir option. In this case basefolder is
+`${home-dir}`.
 
 ## `config/device.json`
 
@@ -36,7 +45,7 @@ The format of the json file is
 }
 ```
 
-The `ProductId` in the configuration is the product is which is
+The `ProductId` in the configuration is the product which is
 configured for the group of devices. The product id is found in the cloud
 console.
 

--- a/apps/tcp_tunnel_device/src/tcp_tunnel.h
+++ b/apps/tcp_tunnel_device/src/tcp_tunnel.h
@@ -14,6 +14,7 @@ struct tcp_tunnel {
 };
 
 bool tcp_tunnel_config_interactive(struct tcp_tunnel* tcpTunnel);
+bool tcp_tunnel_demo_config(struct tcp_tunnel* tcpTunnel);
 void tcp_tunnel_deinit(struct tcp_tunnel* tcpTunnel);
 
 #endif

--- a/apps/tcp_tunnel_device/src/tcp_tunnel_init.c
+++ b/apps/tcp_tunnel_device/src/tcp_tunnel_init.c
@@ -452,6 +452,23 @@ bool tcp_tunnel_demo_config(struct tcp_tunnel* tcpTunnel)
         return false;
     }
 
+    bool createIamConfig = false;
+    if (string_file_exists(tcpTunnel->iamConfigFile)) {
+        printf("The IAM configuration already exists (%s)" NEWLINE, tcpTunnel->iamConfigFile);
+        createIamConfig = prompt_yes_no("Do you want to recreate it?");
+    } else {
+        printf("No IAM configuration found. Creating configuration: %s" NEWLINE, tcpTunnel->iamConfigFile);
+        createIamConfig = true;
+    }
+
+    if (createIamConfig) {
+        if (!iam_config_create_default(tcpTunnel->iamConfigFile)) {
+            printf("The IAM configuration file %s could not be created." NEWLINE, tcpTunnel->iamConfigFile);
+            return false;
+        }
+    }
+    printf(NEWLINE);
+
     printf(
         "Demo initialization will make a simple IAM setup, be aware that this is not what you want in production." NEWLINE
         "Local Open Pairing and Password Open Pairing are enabled. Newly paired users get the Administrator role." NEWLINE NEWLINE
@@ -538,7 +555,7 @@ bool tcp_tunnel_demo_config(struct tcp_tunnel* tcpTunnel)
                 const char* key = "rtsp-path";
                 char value[20] = {0};
 
-                prompt_repeating("Enter your RTSP endpoint (e.g. /cam)", value, ARRAY_SIZE(value));
+                prompt_repeating("Enter your RTSP endpoint (e.g. /video)", value, ARRAY_SIZE(value));
 
                 nn_string_map_insert(&service->metadata, key, value);
 

--- a/apps/tcp_tunnel_device/src/tcp_tunnel_init.c
+++ b/apps/tcp_tunnel_device/src/tcp_tunnel_init.c
@@ -29,11 +29,13 @@ bool create_services_interactive(const char* file);
 
 bool yes_no();
 
-int is_printable(char c) {
+static inline bool is_printable(char c)
+{
     return c >= 0x20 && c <= 0x7e;
 }
 
-bool tcp_tunnel_config_interactive(struct tcp_tunnel* tcpTunnel) {
+static bool prompt_create_device_config(struct tcp_tunnel* tcpTunnel) 
+{
     bool createDeviceConfig = false;
     if (string_file_exists(tcpTunnel->deviceConfigFile)) {
         printf("A device configuration already exists (%s)" NEWLINE "Do you want to recreate it? ", tcpTunnel->deviceConfigFile);
@@ -48,6 +50,14 @@ bool tcp_tunnel_config_interactive(struct tcp_tunnel* tcpTunnel) {
         }
     }
     printf(NEWLINE);
+    return true;
+}
+
+bool tcp_tunnel_config_interactive(struct tcp_tunnel* tcpTunnel) {
+    bool createDeviceConfigSuccess = prompt_create_device_config(tcpTunnel);
+    if (!createDeviceConfigSuccess) {
+        return false;
+    }
 
     bool createIamConfig = false;
     if (string_file_exists(tcpTunnel->iamConfigFile)) {
@@ -385,4 +395,13 @@ bool create_services_interactive(const char* file)
         printf("Use default services" NEWLINE);
         return tcp_tunnel_create_default_services_file(file);
     }
+}
+
+bool tcp_tunnel_demo_config(struct tcp_tunnel* tcpTunnel)
+{
+    bool createDeviceConfigSuccess = prompt_create_device_config(tcpTunnel);
+    if (!createDeviceConfigSuccess) {
+        return false;
+    }
+    return true;
 }

--- a/apps/tcp_tunnel_device/src/tcp_tunnel_main.c
+++ b/apps/tcp_tunnel_device/src/tcp_tunnel_main.c
@@ -374,7 +374,7 @@ bool handle_main(struct args* args, struct tcp_tunnel* tunnel)
             print_private_key_file_load_failed(tunnel->privateKeyFile);
             return false;
         }
-        
+
         bool success = false;
         if (args->demo_init) {
             success = tcp_tunnel_demo_config(tunnel);
@@ -396,17 +396,17 @@ bool handle_main(struct args* args, struct tcp_tunnel* tunnel)
     } else {
         // check that all files exists
         if (!string_file_exists(tunnel->deviceConfigFile)) {
-            printf("Missing device config %s, initialize it with --init" NEWLINE, tunnel->deviceConfigFile);
+            printf("Missing device config %s, initialize it with --init or --demo-init" NEWLINE, tunnel->deviceConfigFile);
             return false;
         }
 
         if(!string_file_exists(tunnel->iamConfigFile)) {
-            printf("Missing IAM configuration file %s, create it with --init" NEWLINE, tunnel->iamConfigFile);
+            printf("Missing IAM configuration file %s, create it with --init or --demo-init" NEWLINE, tunnel->iamConfigFile);
             return false;
         }
 
         if (!string_file_exists(tunnel->stateFile)) {
-            printf("Missing IAM state file %s, create it with --init" NEWLINE, tunnel->stateFile);
+            printf("Missing IAM state file %s, create it with --init or --demo-init" NEWLINE, tunnel->stateFile);
             return false;
         }
     }


### PR DESCRIPTION
* Adds `--demo-init` to tcp_tunnel_device
* Refactored tcp_tunnel_device to avoid using scanf.

scanf is usually error-prone and was in fact the cause of the bugs outlined in SC-1591 since it cannot recognize empty strings and also leaves newline control characters in the stdin stream. It also produces hard to read code such as
```c
  if (scanf("%20s", host) != 1) {
      char i=0;
      while (i != '\n') { (void)scanf("%c", &i); }
      printf("Service creation failed. Invalid service host entered." NEWLINE);
      return false;
  }
```
The above would also output compiler warnings due to the output of scanf being ignored in `(void)scanf("%c", &i);`