### PR TITLE
Mbedtls 3.5 change

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         cli-only: [0, 1]
-        os: [windows-2022, ubuntu-22.04, macos-13]
+        os: [windows-2022, ubuntu-22.04, macos-12]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-test:
-    timeout-minutes: 30
+    timeout-minutes: 40
     name: Build
     runs-on: ${{matrix.os}}
     strategy:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -7,13 +7,13 @@ on:
 
 jobs:
   build-and-test:
-    timeout-minutes: 40
+    timeout-minutes: 20
     name: Build
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
         cli-only: [0, 1]
-        os: [windows-2022, ubuntu-22.04, macos-12]
+        os: [windows-2022, ubuntu-22.04, macos-13]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -22,7 +22,7 @@ jobs:
             friendly_name: macos
     name: Build
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 40
 
     steps:
       - uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
           if-no-files-found: error
 
   build-linux-arm:
-    timeout-minutes: 20
+    timeout-minutes: 40
     strategy:
       matrix:
         arch: [armv6, armhf, aarch64]
@@ -118,7 +118,7 @@ jobs:
 
 
   upload-artifacts:
-    timeout-minutes: 20
+    timeout-minutes: 40
     strategy:
       matrix:
         binary: [tcp_tunnel_device, thermostat_device]

--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-2022, ubuntu-20.04, macos-13]
+        os: [windows-2022, ubuntu-20.04, macos-12]
         include:
           - os: windows-2022
             exe_postfix: .exe
@@ -17,12 +17,12 @@ jobs:
           - os: ubuntu-20.04
             exe_postfix:
             friendly_name: linux_x86_64
-          - os: macos-13
+          - os: macos-12
             exe_postfix:
             friendly_name: macos
     name: Build
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
           if-no-files-found: error
 
   build-linux-arm:
-    timeout-minutes: 40
+    timeout-minutes: 20
     strategy:
       matrix:
         arch: [armv6, armhf, aarch64]
@@ -118,7 +118,7 @@ jobs:
 
 
   upload-artifacts:
-    timeout-minutes: 40
+    timeout-minutes: 20
     strategy:
       matrix:
         binary: [tcp_tunnel_device, thermostat_device]

--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-2022, ubuntu-20.04, macos-12]
+        os: [windows-2022, ubuntu-20.04, macos-13]
         include:
           - os: windows-2022
             exe_postfix: .exe
@@ -17,7 +17,7 @@ jobs:
           - os: ubuntu-20.04
             exe_postfix:
             friendly_name: linux_x86_64
-          - os: macos-12
+          - os: macos-13
             exe_postfix:
             friendly_name: macos
     name: Build

--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -33,7 +33,7 @@ jobs:
         run: mkdir build-dir && cd build-dir && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/artifacts -DDEVICE_STATIC_LINK_VCRUNTIME=ON ..
 
       - name: Build
-        run: cmake --build build-dir --parallel
+        run: cmake --build build-dir --parallel 8
 
       - name: Install
         run: cmake --build build-dir --target install

--- a/.github/workflows/build_linux_mbedtls_3.yml
+++ b/.github/workflows/build_linux_mbedtls_3.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: recursive
           fetch-depth: 0
       - name: Change MbedTLS version
-        run: cd 3rdparty/mbedtls/mbedtls && git fetch && git checkout v3.2.1
+        run: cd 3rdparty/mbedtls/mbedtls && git fetch && git checkout v3.5.1
 
       - name: Configure cmake
         run: mkdir build-dir && cd build-dir && cmake -DDEVICE_BUILD_TESTS=ON -DDEVICE_MBEDTLS_2=OFF -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/artifacts ..

--- a/3rdparty/mbedtls/CMakeLists.txt
+++ b/3rdparty/mbedtls/CMakeLists.txt
@@ -7,75 +7,45 @@ set(src_dir ${CMAKE_CURRENT_SOURCE_DIR}/mbedtls/library)
 set(src_crypto
     ${src_dir}/aes.c
     ${src_dir}/aesni.c
-  #  ${src_dir}/arc4.c
     ${src_dir}/asn1parse.c
     ${src_dir}/asn1write.c
     ${src_dir}/base64.c
     ${src_dir}/bignum.c
-  #  ${src_dir}/blowfish.c
-  #  ${src_dir}/camellia.c
     ${src_dir}/ccm.c
     ${src_dir}/cipher.c
     ${src_dir}/cipher_wrap.c
-  #  ${src_dir}/cmac.c
     ${src_dir}/ctr_drbg.c
-  #  ${src_dir}/des.c
-  #  ${src_dir}/dhm.c
     ${src_dir}/ecdh.c
     ${src_dir}/ecdsa.c
-  #  ${src_dir}/ecjpake.c
     ${src_dir}/ecp.c
     ${src_dir}/ecp_curves.c
     ${src_dir}/entropy.c
     ${src_dir}/entropy_poll.c
     ${src_dir}/error.c
-  #  ${src_dir}/gcm.c
-   # ${src_dir}/havege.c
     ${src_dir}/hmac_drbg.c
     ${src_dir}/md.c
-  #  ${src_dir}/md2.c
-  #  ${src_dir}/md4.c
-  #  ${src_dir}/md5.c
-  #  ${src_dir}/md_wrap.c
-  #  ${src_dir}/memory_buffer_alloc.c
     ${src_dir}/oid.c
-  #  ${src_dir}/padlock.c
     ${src_dir}/pem.c
     ${src_dir}/pk.c
     ${src_dir}/pk_wrap.c
-  #  ${src_dir}/pkcs12.c
-  #  ${src_dir}/pkcs5.c
     ${src_dir}/pkparse.c
     ${src_dir}/pkwrite.c
     ${src_dir}/platform.c
     ${src_dir}/platform_util.c
-  #  ${src_dir}/ripemd160.c
-  #  ${src_dir}/rsa.c
-  #  ${src_dir}/rsa_internal.c
-   # ${src_dir}/sha1.c
     ${src_dir}/sha256.c
-   # ${src_dir}/sha512.c
-   # ${src_dir}/threading.c
-   # ${src_dir}/timing.c
-   # ${src_dir}/version.c
-   # ${src_dir}/version_features.c
-   # ${src_dir}/xtea.c
     ${src_dir}/constant_time.c
     )
 
-set(src_x509
-   # ${src_dir}/certs.c
-    #${src_dir}/pkcs11.c
-    ${src_dir}/x509.c
-    ${src_dir}/x509_create.c
-    #${src_dir}/x509_crl.c
-    ${src_dir}/x509_crt.c
-    #${src_dir}/x509_csr.c
-    ${src_dir}/x509write_crt.c
-    #${src_dir}/x509write_csr.c
-)
 
 if (DEVICE_MBEDTLS_2)
+set(src_x509
+    ${src_dir}/x509.c
+    ${src_dir}/x509_create.c
+    ${src_dir}/x509_crt.c
+    ${src_dir}/x509write_crt.c
+)
+
+
 set(src_tls
     ${src_dir}/debug.c
     ${src_dir}/ssl_cache.c
@@ -87,7 +57,47 @@ set(src_tls
     ${src_dir}/ssl_tls.c
     ${src_dir}/ssl_msg.c
 )
+set(src_crypto
+    ${src_dir}/aes.c
+    ${src_dir}/aesni.c
+    ${src_dir}/asn1parse.c
+    ${src_dir}/asn1write.c
+    ${src_dir}/base64.c
+    ${src_dir}/bignum.c
+    ${src_dir}/ccm.c
+    ${src_dir}/cipher.c
+    ${src_dir}/cipher_wrap.c
+    ${src_dir}/ctr_drbg.c
+    ${src_dir}/ecdh.c
+    ${src_dir}/ecdsa.c
+    ${src_dir}/ecp.c
+    ${src_dir}/ecp_curves.c
+    ${src_dir}/entropy.c
+    ${src_dir}/entropy_poll.c
+    ${src_dir}/error.c
+    ${src_dir}/hmac_drbg.c
+    ${src_dir}/md.c
+    ${src_dir}/oid.c
+    ${src_dir}/pem.c
+    ${src_dir}/pk.c
+    ${src_dir}/pk_wrap.c
+    ${src_dir}/pkparse.c
+    ${src_dir}/pkwrite.c
+    ${src_dir}/platform.c
+    ${src_dir}/platform_util.c
+    ${src_dir}/sha256.c
+    ${src_dir}/constant_time.c
+    )
+
 else()
+set(src_x509
+    ${src_dir}/x509.c
+    ${src_dir}/x509_create.c
+    ${src_dir}/x509_crt.c
+    ${src_dir}/x509write.c
+    ${src_dir}/x509write_crt.c
+)
+
 set(src_tls
     ${src_dir}/debug.c
     ${src_dir}/ssl_cache.c
@@ -101,6 +111,40 @@ set(src_tls
     ${src_dir}/ssl_tls.c
     ${src_dir}/ssl_msg.c
 )
+set(src_crypto
+    ${src_dir}/aes.c
+    ${src_dir}/aesni.c
+    ${src_dir}/asn1parse.c
+    ${src_dir}/asn1write.c
+    ${src_dir}/base64.c
+    ${src_dir}/bignum.c
+    ${src_dir}/bignum_core.c
+    ${src_dir}/ccm.c
+    ${src_dir}/cipher.c
+    ${src_dir}/cipher_wrap.c
+    ${src_dir}/ctr_drbg.c
+    ${src_dir}/ecdh.c
+    ${src_dir}/ecdsa.c
+    ${src_dir}/ecp.c
+    ${src_dir}/ecp_curves.c
+    ${src_dir}/entropy.c
+    ${src_dir}/entropy_poll.c
+    ${src_dir}/error.c
+    ${src_dir}/hmac_drbg.c
+    ${src_dir}/md.c
+    ${src_dir}/oid.c
+    ${src_dir}/pem.c
+    ${src_dir}/pk.c
+    ${src_dir}/pk_wrap.c
+    ${src_dir}/pkparse.c
+    ${src_dir}/pkwrite.c
+    ${src_dir}/platform.c
+    ${src_dir}/platform_util.c
+    ${src_dir}/sha256.c
+    ${src_dir}/constant_time.c
+    )
+
+
 endif()
 
 if (NABTO_DEVICE_MBEDTLS_PROVIDER MATCHES "module")
@@ -111,7 +155,11 @@ add_library(3rdparty_mbedtls "${src_tls}" "${src_x509}" "${src_crypto}" "${confi
 
 target_include_directories(3rdparty_mbedtls PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/config)
 target_include_directories(3rdparty_mbedtls PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbedtls/include)
-target_compile_definitions(3rdparty_mbedtls PUBLIC -DMBEDTLS_CONFIG_FILE=<nabto_mbedtls_config.h>)
+if (DEVICE_MBEDTLS_2)
+  target_compile_definitions(3rdparty_mbedtls PUBLIC -DMBEDTLS_CONFIG_FILE=<nabto_mbedtls_config.h>)
+else()
+  target_compile_definitions(3rdparty_mbedtls PUBLIC -DMBEDTLS_CONFIG_FILE=<nabto_mbedtls_config_v3.h>)
+endif()
 
 else()
   find_package(MbedTLS REQUIRED)

--- a/3rdparty/mbedtls/config/nabto_mbedtls_config_v3.h
+++ b/3rdparty/mbedtls/config/nabto_mbedtls_config_v3.h
@@ -1,0 +1,144 @@
+/**
+ * \file config-suite-b.h
+ *
+ * \brief Minimal configuration for TLS NSA Suite B Profile (RFC 6460)
+ */
+/*
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+/*
+ * Minimal configuration for TLS NSA Suite B Profile (RFC 6460)
+ *
+ * Distinguishing features:
+ * - no RSA or classic DH, fully based on ECC
+ * - optimized for low RAM usage
+ *
+ * Possible improvements:
+ * - if 128-bit security is enough, disable secp384r1 and SHA-512
+ * - use embedded certs in DER format and disable PEM_PARSE_C and BASE64_C
+ *
+ * See README.txt for usage instructions.
+ */
+
+#ifndef MBEDTLS_CONFIG_H
+#define MBEDTLS_CONFIG_H
+
+/* System support */
+#define MBEDTLS_HAVE_ASM
+#define MBEDTLS_HAVE_TIME
+#define MBEDTLS_HAVE_TIME_DATE
+
+#if defined(_WIN32)
+#define MBEDTLS_PLATFORM_C
+#endif
+
+/* mbed TLS feature support */
+#define MBEDTLS_ECP_DP_SECP256R1_ENABLED
+//#define MBEDTLS_ECP_DP_SECP384R1_ENABLED
+#define MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
+#define MBEDTLS_SSL_PROTO_TLS1_2
+
+/* mbed TLS modules */
+#define MBEDTLS_AES_C
+#define MBEDTLS_AESNI_C
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_ASN1_WRITE_C
+#define MBEDTLS_BIGNUM_C
+#define MBEDTLS_CIPHER_C
+#define MBEDTLS_CTR_DRBG_C
+#define MBEDTLS_ECDH_C
+#define MBEDTLS_ECDSA_C
+#define MBEDTLS_ECP_C
+#define MBEDTLS_ENTROPY_C
+//#define MBEDTLS_GCM_C
+#define MBEDTLS_CCM_C
+#define MBEDTLS_MD_C
+//#define MBEDTLS_NET_C
+#define MBEDTLS_OID_C
+#define MBEDTLS_PEM_WRITE_C
+#define MBEDTLS_PK_C
+#define MBEDTLS_PK_PARSE_C
+#define MBEDTLS_PK_WRITE_C
+#define MBEDTLS_SHA224_C
+#define MBEDTLS_SHA256_C
+//#define MBEDTLS_SHA512_C
+#define MBEDTLS_SSL_ALPN
+#define MBEDTLS_SSL_CLI_C
+#define MBEDTLS_SSL_SRV_C
+#define MBEDTLS_SSL_COOKIE_C
+#define MBEDTLS_SSL_PROTO_DTLS
+#define MBEDTLS_SSL_DTLS_HELLO_VERIFY
+#define MBEDTLS_SSL_TLS_C
+#define MBEDTLS_X509_CRT_PARSE_C
+#define MBEDTLS_X509_CRT_WRITE_C
+#define MBEDTLS_X509_CREATE_C
+#define MBEDTLS_X509_USE_C
+#define MBEDTLS_SSL_SERVER_NAME_INDICATION
+#define MBEDTLS_DEBUG_C
+#define MBEDTLS_ERROR_C
+#define MBEDTLS_SSL_DTLS_ANTI_REPLAY
+
+#define MBEDTLS_PLATFORM_C
+#define MBEDTLS_PLATFORM_MEMORY
+
+/* For test certificates */
+#define MBEDTLS_BASE64_C
+#define MBEDTLS_CERTS_C
+#define MBEDTLS_PEM_PARSE_C
+
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
+#define MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
+
+/* Save RAM at the expense of ROM */
+#define MBEDTLS_AES_ROM_TABLES
+
+/* Save RAM by adjusting to our exact needs */
+#define MBEDTLS_ECP_MAX_BITS   256
+#define MBEDTLS_MPI_MAX_SIZE    48 // 384 bits is 48 bytes
+
+/* Save RAM at the expense of speed, see ecp.h */
+#define MBEDTLS_ECP_WINDOW_SIZE        2
+#define MBEDTLS_ECP_FIXED_POINT_OPTIM  0
+
+/* Significant speed benefit at the expense of some ROM */
+#define MBEDTLS_ECP_NIST_OPTIM
+
+/*
+ * You should adjust this to the exact number of sources you're using: default
+ * is the "mbedtls_platform_entropy_poll" source, but you may want to add other ones.
+ * Minimum is 2 for the entropy test suite.
+ */
+#define MBEDTLS_ENTROPY_MAX_SOURCES 2
+
+/* Save ROM and a few bytes of RAM by specifying our own ciphersuite list */
+#define MBEDTLS_SSL_CIPHERSUITES                        \
+  MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CCM
+
+/*
+ * Save RAM at the expense of interoperability: do this only if you control
+ * both ends of the connection!  (See coments in "mbedtls/ssl.h".)
+ * The minimum size here depends on the certificate chain used as well as the
+ * typical size of records.
+ */
+#define MBEDTLS_SSL_MAX_CONTENT_LEN             2048
+
+
+#include "mbedtls/config_adjust_legacy_crypto.h"
+#include "mbedtls/check_config.h"
+
+#endif /* MBEDTLS_CONFIG_H */

--- a/src/modules/mbedtls/nm_mbedtls_util.c
+++ b/src/modules/mbedtls/nm_mbedtls_util.c
@@ -95,12 +95,17 @@ np_error_code nm_dtls_create_crt_from_private_key_inner(struct crt_from_private_
     mbedtls_x509write_crt_set_subject_key( &ctx->crt, &ctx->key );
     mbedtls_x509write_crt_set_issuer_key( &ctx->crt, &ctx->key );
 
+#if MBEDTLS_VERSION_MAJOR >= 3
+    unsigned char serial[1] = { 0x01 };
+    ret = mbedtls_x509write_crt_set_serial_raw(&ctx->crt, serial, 1);
+#else
     ret = mbedtls_mpi_read_string( &ctx->serial, 10, "1");
     if (ret != 0) {
         return NABTO_EC_UNKNOWN;
     }
 
     mbedtls_x509write_crt_set_serial( &ctx->crt, &ctx->serial );
+#endif
 
     ret = mbedtls_x509write_crt_set_subject_name( &ctx->crt, "CN=nabto" );
     if (ret != 0) {


### PR DESCRIPTION
mbedtls has deprecated a function between 3.2 and 3.5, so upgrading the 3.x target to 3.5.1