### PR TITLE
we have documented that a tcp socket which cannot be connected becaus…

### DIFF
--- a/src/modules/select_unix/nm_select_unix_tcp.c
+++ b/src/modules/select_unix/nm_select_unix_tcp.c
@@ -290,6 +290,10 @@ np_error_code is_connected_ec(struct np_tcp_socket* sock)
         // Wait for next event
         return NABTO_EC_AGAIN;
     }
+    if (err == ECONNREFUSED) {
+        NABTO_LOG_TRACE(LOG, "Cannot connect socket %s", strerror(err));
+        return NABTO_EC_ABORTED;
+    }
     NABTO_LOG_ERROR(LOG, "Cannot connect socket %s", strerror(err));
     return NABTO_EC_UNKNOWN;
 }


### PR DESCRIPTION
…e the connection is refused, should return NABTO_EC_ABORTED