### PR TITLE
Fix double free of DNS host string in stun / dns multi resolver

### DIFF
--- a/src/core/nc_dns_multi_resolver.c
+++ b/src/core/nc_dns_multi_resolver.c
@@ -17,6 +17,9 @@ void print_dns_results(struct nc_dns_multi_resolver_context* ctx, np_error_code 
 np_error_code nc_dns_multi_resolver_init(struct np_platform* pl, struct nc_dns_multi_resolver_context* ctx)
 {
     ctx->pl = pl;
+    ctx->host = NULL;
+    ctx->v4Ec = NABTO_EC_OK;
+    ctx->v6Ec = NABTO_EC_OK;
     struct np_event_queue* eq = &pl->eq;
     np_error_code ec = np_completion_event_init(eq, &ctx->v4CompletionEvent, &dns_resolved_callback_v4, ctx);
     if (ec != NABTO_EC_OK) {
@@ -38,6 +41,15 @@ void nc_dns_multi_resolver_deinit(struct nc_dns_multi_resolver_context* ctx)
 void nc_dns_multi_resolver_resolve(struct nc_dns_multi_resolver_context* ctx, const char* host, struct np_ip_address* ips, size_t ipsSize, size_t* ipsResolved, struct np_completion_event* completionEvent)
 {
     struct np_platform* pl = ctx->pl;
+    if (ctx->v4Ec == NABTO_EC_OPERATION_IN_PROGRESS ||
+        ctx->v6Ec == NABTO_EC_OPERATION_IN_PROGRESS)
+    {
+        // A resolve is already outstanding; starting a new one would clobber
+        // the in-flight state and completion events.
+        NABTO_LOG_ERROR(LOG, "DNS resolve requested while a resolve is already in progress");
+        np_completion_event_resolve(completionEvent, NABTO_EC_OPERATION_IN_PROGRESS);
+        return;
+    }
     ctx->resolvedCompletionEvent = completionEvent;
     ctx->ips = ips;
     ctx->ipsSize = ipsSize;
@@ -104,6 +116,7 @@ void dns_resolved(struct nc_dns_multi_resolver_context* ctx)
     np_error_code ec = dns_resolved_ec(ctx);
     print_dns_results(ctx, ec);
     np_free(ctx->host);
+    ctx->host = NULL;
     np_completion_event_resolve(ctx->resolvedCompletionEvent, ec);
 }
 

--- a/src/core/nc_dns_multi_resolver.h
+++ b/src/core/nc_dns_multi_resolver.h
@@ -6,6 +6,10 @@
 #include <platform/np_error_code.h>
 #include <platform/np_ip_address.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Resolves ipv4 and ipv6 addresses and builds an array of the
  * resulting addresses with alternating ipv4 and ipv6 addresses.
@@ -39,5 +43,9 @@ np_error_code nc_dns_multi_resolver_init(struct np_platform* pl, struct nc_dns_m
 void nc_dns_multi_resolver_deinit(struct nc_dns_multi_resolver_context* ctx);
 
 void nc_dns_multi_resolver_resolve(struct nc_dns_multi_resolver_context* ctx, const char* host, struct np_ip_address* ips, size_t ipsSize, size_t* ipsResolved, struct np_completion_event* event);
+
+#ifdef __cplusplus
+} // extern c
+#endif
 
 #endif

--- a/src/core/nc_stun.c
+++ b/src/core/nc_stun.c
@@ -153,13 +153,14 @@ np_error_code nc_stun_async_analyze_simple(struct nc_stun_context* ctx, struct n
     }
     nn_llist_append(&ctx->cbs, &callback->callbackNode, callback);
 
-    if (ctx->state == NC_STUN_STATE_RUNNING) {
+    if (ctx->state == NC_STUN_STATE_RESOLVING ||
+        ctx->state == NC_STUN_STATE_RUNNING) {
         NABTO_LOG_INFO(LOG, "Stun already running, adding callback");
         return NABTO_EC_OK;
     }
 
     ctx->simple = true;
-    ctx->state = NC_STUN_STATE_RUNNING;
+    ctx->state = NC_STUN_STATE_RESOLVING;
     nc_dns_multi_resolver_resolve(&ctx->dnsMultiResolver, ctx->hostname, ctx->resolvedIps, NC_STUN_MAX_ENDPOINTS, &ctx->resolvedIpsSize, &ctx->dnsCompletionEvent);
 
     return NABTO_EC_OK;
@@ -174,6 +175,12 @@ void nc_stun_handle_packet(struct nc_stun_context* ctx,
     (void)ep;
     if (ctx->state == NC_STUN_STATE_ABORTED) {
         NABTO_LOG_ERROR(LOG, "Stun packet received for deinitialized stun context");
+        return;
+    }
+    if (ctx->state != NC_STUN_STATE_RUNNING) {
+        // e.g. a late response from a previous analysis round. The stun state
+        // machine is not active, so the event it reports would be stale.
+        NABTO_LOG_TRACE(LOG, "Ignoring stun packet since no analysis is running");
         return;
     }
     NABTO_LOG_TRACE(LOG, "Stun handling packet");
@@ -299,6 +306,7 @@ void nc_stun_dns_cb(const np_error_code ec, void* data)
     ctx->numEps = nc_stun_convert_ep_list(ctx->resolvedIps, ctx->resolvedIpsSize, ctx->eps, NC_STUN_MAX_ENDPOINTS, ctx->priPort);
     nabto_stun_init(&ctx->stun, &ctx->stunModule, ctx, ctx->eps, (uint8_t)ctx->numEps);
     nabto_stun_async_analyze(&ctx->stun, ctx->simple);
+    ctx->state = NC_STUN_STATE_RUNNING;
     nc_stun_event(ctx);
 }
 
@@ -306,6 +314,10 @@ void nc_stun_send_to_cb(const np_error_code ec, void* data)
 {
     (void)ec;
     struct nc_stun_context* ctx = (struct nc_stun_context*)data;
+    if (ctx->state != NC_STUN_STATE_RUNNING) {
+        NABTO_LOG_TRACE(LOG, "Ignoring stun send completion since no analysis is running");
+        return;
+    }
     // send errors is ok in stun context
     nc_stun_event(ctx);
 }
@@ -313,6 +325,10 @@ void nc_stun_send_to_cb(const np_error_code ec, void* data)
 void nc_stun_handle_timeout(void* data)
 {
     struct nc_stun_context* ctx = (struct nc_stun_context*)data;
+    if (ctx->state != NC_STUN_STATE_RUNNING) {
+        NABTO_LOG_TRACE(LOG, "Ignoring stun timeout since no analysis is running");
+        return;
+    }
     nabto_stun_handle_wait_event(&ctx->stun);
     nc_stun_event(ctx);
 }

--- a/src/core/nc_stun.h
+++ b/src/core/nc_stun.h
@@ -37,6 +37,7 @@ struct nc_stun_callback {
 
 enum nc_stun_state {
     NC_STUN_STATE_NONE = 0,
+    NC_STUN_STATE_RESOLVING,
     NC_STUN_STATE_RUNNING,
     NC_STUN_STATE_DONE,
     NC_STUN_STATE_ABORTED

--- a/test_cpp/CMakeLists.txt
+++ b/test_cpp/CMakeLists.txt
@@ -57,6 +57,7 @@ set(test_src
   tests/dns/dns_test.cpp
   tests/local_ping/local_ping_test.cpp
   tests/core/nc_coap_rest_error_test.cpp
+  tests/core/nc_dns_multi_resolver_test.cpp
   tests/core/watchdog_test.cpp
   tests/spake2/spake2_test.cpp
   tests/spake2/spake2_mbedtls_test.cpp

--- a/test_cpp/tests/core/nc_dns_multi_resolver_test.cpp
+++ b/test_cpp/tests/core/nc_dns_multi_resolver_test.cpp
@@ -1,0 +1,119 @@
+#include <boost/test/unit_test.hpp>
+
+#include <test_platform.hpp>
+#include <test_platform_libevent.hpp>
+
+#include <core/nc_dns_multi_resolver.h>
+#include <platform/np_completion_event.h>
+#include <platform/np_platform.h>
+
+#include <future>
+
+namespace {
+
+// DNS mock which captures the resolve requests such that the test controls
+// when and how they are resolved.
+struct MockDns {
+    struct np_ip_address* v4Ips = NULL;
+    size_t* v4IpsResolved = NULL;
+    struct np_completion_event* v4CompletionEvent = NULL;
+    struct np_completion_event* v6CompletionEvent = NULL;
+};
+
+void mock_async_resolve_v4(struct np_dns* obj, const char* host, struct np_ip_address* ips, size_t ipsSize, size_t* ipsResolved, struct np_completion_event* completionEvent)
+{
+    (void)host; (void)ipsSize;
+    MockDns* mock = (MockDns*)obj->data;
+    mock->v4Ips = ips;
+    mock->v4IpsResolved = ipsResolved;
+    mock->v4CompletionEvent = completionEvent;
+}
+
+void mock_async_resolve_v6(struct np_dns* obj, const char* host, struct np_ip_address* ips, size_t ipsSize, size_t* ipsResolved, struct np_completion_event* completionEvent)
+{
+    (void)host; (void)ips; (void)ipsSize; (void)ipsResolved;
+    MockDns* mock = (MockDns*)obj->data;
+    mock->v6CompletionEvent = completionEvent;
+}
+
+struct np_dns_functions mockDnsModule = {
+    &mock_async_resolve_v4,
+    &mock_async_resolve_v6
+};
+
+class CompletionWaiter {
+ public:
+    CompletionWaiter(struct np_platform* pl)
+    {
+        np_completion_event_init(&pl->eq, &completionEvent_, &CompletionWaiter::callback, this);
+    }
+    ~CompletionWaiter()
+    {
+        np_completion_event_deinit(&completionEvent_);
+    }
+    static void callback(const np_error_code ec, void* data)
+    {
+        CompletionWaiter* self = (CompletionWaiter*)data;
+        self->promise_.set_value(ec);
+    }
+    np_error_code wait()
+    {
+        return promise_.get_future().get();
+    }
+    struct np_completion_event completionEvent_;
+ private:
+    std::promise<np_error_code> promise_;
+};
+
+}
+
+BOOST_AUTO_TEST_SUITE(dns_multi_resolver)
+
+BOOST_TEST_DECORATOR(* boost::unit_test::timeout(120))
+
+BOOST_AUTO_TEST_CASE(overlapping_resolve_is_rejected)
+{
+    auto tp = std::make_unique<nabto::test::TestPlatformLibevent>();
+    struct np_platform* pl = tp->getPlatform();
+
+    MockDns mock;
+    pl->dns.mptr = &mockDnsModule;
+    pl->dns.data = &mock;
+
+    struct nc_dns_multi_resolver_context ctx;
+    BOOST_TEST(nc_dns_multi_resolver_init(pl, &ctx) == NABTO_EC_OK);
+    {
+        CompletionWaiter first(pl);
+        CompletionWaiter second(pl);
+
+        struct np_ip_address ips[NC_DNS_MULTI_RESOLVER_MAX_IPS];
+        size_t ipsResolved = 0;
+        nc_dns_multi_resolver_resolve(&ctx, "example.com", ips, NC_DNS_MULTI_RESOLVER_MAX_IPS, &ipsResolved, &first.completionEvent_);
+        BOOST_TEST(mock.v4CompletionEvent != (struct np_completion_event*)NULL);
+        BOOST_TEST(mock.v6CompletionEvent != (struct np_completion_event*)NULL);
+
+        // A resolve is outstanding, a second resolve must be rejected without
+        // clobbering the in-flight state.
+        struct np_ip_address ips2[NC_DNS_MULTI_RESOLVER_MAX_IPS];
+        size_t ipsResolved2 = 0;
+        nc_dns_multi_resolver_resolve(&ctx, "example.com", ips2, NC_DNS_MULTI_RESOLVER_MAX_IPS, &ipsResolved2, &second.completionEvent_);
+        BOOST_TEST(second.wait() == NABTO_EC_OPERATION_IN_PROGRESS);
+
+        // The outstanding resolve completes as usual.
+        mock.v4Ips[0].type = NABTO_IPV4;
+        memset(mock.v4Ips[0].ip.v6, 0, 16);
+        mock.v4Ips[0].ip.v4[0] = 1;
+        mock.v4Ips[0].ip.v4[1] = 2;
+        mock.v4Ips[0].ip.v4[2] = 3;
+        mock.v4Ips[0].ip.v4[3] = 4;
+        *mock.v4IpsResolved = 1;
+        np_completion_event_resolve(mock.v4CompletionEvent, NABTO_EC_OK);
+        np_completion_event_resolve(mock.v6CompletionEvent, NABTO_EC_UNKNOWN);
+        BOOST_TEST(first.wait() == NABTO_EC_OK);
+        BOOST_TEST(ipsResolved == (size_t)1);
+        BOOST_TEST(ctx.host == (char*)NULL);
+    }
+    nc_dns_multi_resolver_deinit(&ctx);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
With many concurrent clients requesting rendezvous endpoints, a late STUN response could re-enter nc_stun_event() while a new analysis round was still resolving DNS. The nabto_stun state machine's nextEvent stays at STUN_ET_COMPLETED after a round finishes, so the stale event flipped the context to DONE with the resolve still in flight. The next analyze call then started a second overlapping nc_dns_multi_resolver_resolve, and the interleaved v4/v6 completions made dns_resolved() free ctx->host twice, crashing in musl's free() once the heap slab had been recycled by concurrent DTLS handshakes.

- nc_stun: add NC_STUN_STATE_RESOLVING for the DNS phase and ignore packets, send completions and timeouts unless an analysis round is actually RUNNING, so stale events cannot advance the state machine.
- nc_dns_multi_resolver: reject overlapping resolves with NABTO_EC_OPERATION_IN_PROGRESS instead of clobbering in-flight state, clear ctx->host after freeing it and initialize the error codes explicitly.
- add a unit test covering the overlapping resolve rejection using a mock DNS module; give nc_dns_multi_resolver.h extern "C" guards so the C++ test can link against it.